### PR TITLE
Android memory leak fix | Solution 1

### DIFF
--- a/MPowerKit.Popups/Platforms/Android/PopupService.cs
+++ b/MPowerKit.Popups/Platforms/Android/PopupService.cs
@@ -77,34 +77,6 @@ public partial class PopupService
         }
         pv.ViewDetachedFromWindow += detachedHandler;
 
-        bool keyboardVisible = false;
-
-        void globalLayoutHandler(object? s, EventArgs e)
-        {
-            var view = dv.FindViewById(Android.Resource.Id.Content);
-
-            var r = new Android.Graphics.Rect();
-            view!.GetWindowVisibleDisplayFrame(r);
-            int screenHeight = view.RootView!.Height;
-
-            // r.bottom is the position above soft keypad or device button.
-            // if keypad is shown, the r.bottom is smaller than that before.
-            int keypadHeight = screenHeight - r.Bottom;
-
-            if (keypadHeight > screenHeight * 0.15)
-            {
-                if (!keyboardVisible)
-                {
-                    keyboardVisible = true;
-                }
-            }
-            else if (keyboardVisible)
-            {
-                keyboardVisible = false;
-            }
-        }
-        pv.ViewTreeObserver!.GlobalLayout += globalLayoutHandler;
-
         void touchHandler(object? s, View.TouchEventArgs e)
         {
             var view = (s as ViewGroup)!;
@@ -121,11 +93,8 @@ public partial class PopupService
                 if (rawx >= childx && rawx <= (child.Width + childx)
                     && rawy >= childy && rawy <= (child.Height + childy))
                 {
-                    if (keyboardVisible)
-                    {
-                        view.Context!.HideKeyboard(view);
-                        view.FindFocus()?.ClearFocus();
-                    }
+                    view.Context!.HideKeyboard(view);
+                    view.FindFocus()?.ClearFocus();
 
                     e.Handled = true;
                     return;
@@ -134,7 +103,7 @@ public partial class PopupService
 
             if (e.Event!.Action is MotionEventActions.Down)
             {
-                if (!page.BackgroundInputTransparent && keyboardVisible)
+                if (!page.BackgroundInputTransparent)
                 {
                     view.Context!.HideKeyboard(view);
                     view.FindFocus()?.ClearFocus();
@@ -156,7 +125,6 @@ public partial class PopupService
         {
             pv.ViewAttachedToWindow -= attachedHandler;
             pv.ViewDetachedFromWindow -= detachedHandler;
-            pv.ViewTreeObserver!.GlobalLayout -= globalLayoutHandler;
             pv.Touch -= touchHandler;
         });
         page.SetValue(DisposableActionAttached.DisposableActionProperty, action);

--- a/MPowerKit.Popups/PopupPage.cs
+++ b/MPowerKit.Popups/PopupPage.cs
@@ -37,32 +37,9 @@ public class PopupPage : ContentPage
 
     public PopupPage()
     {
-        App_Dict_ValuesChanged(null, EventArgs.Empty);
-
-        var dict = Application.Current!.Resources as Microsoft.Maui.Controls.Internals.IResourceDictionary;
-        dict.ValuesChanged += App_Dict_ValuesChanged;
-
         BackgroundColor = Color.FromArgb("#50000000");
 
         Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.Page.SetUseSafeArea(this, HasSystemPadding);
-
-        this.Unloaded += PopupPage_Unloaded;
-    }
-
-    protected virtual void PopupPage_Unloaded(object? sender, EventArgs e)
-    {
-        var dict = Application.Current!.Resources as Microsoft.Maui.Controls.Internals.IResourceDictionary;
-        dict.ValuesChanged -= App_Dict_ValuesChanged;
-    }
-
-    protected virtual void App_Dict_ValuesChanged(object? sender, EventArgs e)
-    {
-        foreach (var dictionary in Application.Current!.Resources.MergedDictionaries)
-        {
-            if (this.Resources.MergedDictionaries.Contains(dictionary)) continue;
-
-            this.Resources.MergedDictionaries.Add(dictionary);
-        }
     }
 
     protected override void OnPropertyChanged([CallerMemberName] string? propertyName = null)


### PR DESCRIPTION
Memory leak detected on Android, reasons:

1. `MergedDictionaries` at the application level are not cleared when `PopupPage` is closed.
2. we subscribe to `pv.ViewTreeObserver!.GlobalLayout` but `ViewTreeObserver `instance can be changed which means there is no guarantee we unsubscribe from `GlobalLayout` and inside the handler we hold a reference to local var `dv` 

Solution 1:

1. Not sure if it is really necessary to add `MergedDictionaries` manually. I just removed this code and tested with `DynamicResource` (Color from App.Resources was used, and the value was changed at runtime). Works as expected.
2. Is `keyboardVisible` necessary? I removed the code and `PopupTestPage `in the Sample app works as expected
_______________________________________
In case we should keep the logic, see [solution 2](https://github.com/MPowerKit/Popups/pull/12)